### PR TITLE
Make provision menu placement on RHS

### DIFF
--- a/examples/lv_ex_settings/lv_ex_settings_2.c
+++ b/examples/lv_ex_settings/lv_ex_settings_2.c
@@ -190,6 +190,7 @@ void lv_ex_settings_2(void)
     /*Create the settings menu with a root item*/
     lv_obj_t *btn = lv_settings_create(&root_item, root_event_cb);
     lv_obj_align(btn, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
+    lv_settings_set_max_width(btn, lv_obj_get_width(lv_scr_act())/2);
 }
 
 /**********************

--- a/examples/lv_ex_settings/lv_ex_settings_2.c
+++ b/examples/lv_ex_settings/lv_ex_settings_2.c
@@ -188,7 +188,8 @@ void lv_ex_settings_2(void)
 
 
     /*Create the settings menu with a root item*/
-    lv_settings_create(&root_item, root_event_cb);
+    lv_obj_t *btn = lv_settings_create(&root_item, root_event_cb);
+    lv_obj_align(btn, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 }
 
 /**********************

--- a/examples/lv_ex_settings/lv_ex_settings_2.c
+++ b/examples/lv_ex_settings/lv_ex_settings_2.c
@@ -190,7 +190,7 @@ void lv_ex_settings_2(void)
     /*Create the settings menu with a root item*/
     lv_obj_t *btn = lv_settings_create(&root_item, root_event_cb);
     lv_obj_align(btn, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
-    lv_settings_set_max_width(btn, lv_obj_get_width(lv_scr_act())/2);
+    lv_settings_set_max_width(lv_obj_get_width(lv_scr_act())/2);
 }
 
 /**********************

--- a/src/lv_settings/lv_settings.c
+++ b/src/lv_settings/lv_settings.c
@@ -14,8 +14,6 @@
 #define LV_SETTINGS_ANIM_TIME   300 /*[ms]*/
 #define LV_SETTINGS_MAX_WIDTH   250
 
-static lv_coord_t settings_max_width = LV_SETTINGS_MAX_WIDTH;
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -93,6 +91,7 @@ static lv_style_t style_bg;
 static lv_style_t style_item_cont;
 static lv_ll_t history_ll;
 static lv_group_t * group;
+static lv_coord_t settings_max_width = LV_SETTINGS_MAX_WIDTH;
 
 /**********************
  *      MACROS

--- a/src/lv_settings/lv_settings.c
+++ b/src/lv_settings/lv_settings.c
@@ -85,6 +85,7 @@ static void old_cont_del_cb(lv_anim_t * a);
  *  STATIC VARIABLES
  **********************/
 static lv_obj_t * act_cont;
+static lv_obj_t * menu_btn;
 static lv_style_t style_menu_bg;
 static lv_style_t style_bg;
 static lv_style_t style_item_cont;
@@ -126,7 +127,7 @@ lv_obj_t * lv_settings_create(lv_settings_item_t * root_item, lv_event_cb_t even
     style_item_cont.body.padding.inner = LV_DPI / 20;
 
 
-    lv_obj_t * menu_btn = lv_btn_create(lv_scr_act(), NULL);
+    menu_btn = lv_btn_create(lv_scr_act(), NULL);
     lv_btn_set_fit(menu_btn, LV_FIT_TIGHT);
     root_ext_t * ext = lv_obj_allocate_ext_attr(menu_btn, sizeof(root_ext_t));
     ext->item = root_item;
@@ -240,7 +241,6 @@ static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb
     lv_obj_t * header = lv_cont_create(act_cont, NULL);
     lv_cont_set_style(header, LV_CONT_STYLE_MAIN, &lv_style_transp_fit);
     lv_cont_set_fit2(header, LV_FIT_NONE, LV_FIT_TIGHT);
-    lv_cont_set_layout(header, LV_LAYOUT_ROW_M);
     lv_obj_set_width(header, lv_obj_get_width(act_cont));
 
     lv_obj_t * header_back_btn = lv_btn_create(header, NULL);
@@ -250,10 +250,20 @@ static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb
     lv_group_focus_obj(header_back_btn);
 
     lv_obj_t * header_back_label = lv_label_create(header_back_btn, NULL);
-    lv_label_set_text(header_back_label, LV_SYMBOL_LEFT);
 
     lv_obj_t * header_title = lv_label_create(header, NULL);
     lv_label_set_text(header_title, parent_item->name);
+
+    bool menu_btn_right = lv_obj_get_x(menu_btn) > lv_obj_get_width(lv_scr_act())/2;
+
+    if(!menu_btn_right ) {
+        lv_cont_set_layout(header, LV_LAYOUT_ROW_M);
+        lv_label_set_text(header_back_label, LV_SYMBOL_LEFT);
+    } else {
+        lv_label_set_text(header_back_label, LV_SYMBOL_RIGHT);
+        lv_obj_align(header_back_btn, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
+        lv_obj_align(header_title, header_back_btn, LV_ALIGN_OUT_LEFT_MID, -act_cont->style_p->body.padding.right, 0);
+    }
 
     lv_obj_set_pos(header, 0, 0);
 
@@ -287,7 +297,11 @@ static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, act_cont, (lv_anim_exec_xcb_t)lv_obj_set_x);
-    lv_anim_set_values(&a, -lv_obj_get_width(act_cont), 0);
+    lv_coord_t w_cont = lv_obj_get_width(act_cont);
+    lv_coord_t w_scr = lv_obj_get_width(lv_scr_act());
+    uint32_t start = !menu_btn_right ? -w_cont : w_scr;
+    uint32_t end = !menu_btn_right ? 0 : w_scr-w_cont;
+    lv_anim_set_values(&a, start, end);
     lv_anim_set_time(&a, LV_SETTINGS_ANIM_TIME, 0);
     lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
     lv_anim_create(&a);
@@ -739,7 +753,12 @@ static void header_back_event_cb(lv_obj_t * btn, lv_event_t e)
         lv_anim_t a;
         lv_anim_init(&a);
         lv_anim_set_exec_cb(&a, old_menu_cont, (lv_anim_exec_xcb_t)lv_obj_set_x);
-        lv_anim_set_values(&a, 0, -lv_obj_get_width(old_menu_cont));
+        lv_coord_t w_scr = lv_obj_get_width(lv_scr_act());
+        bool menu_btn_right = lv_obj_get_x(menu_btn) >= w_scr/2;
+        lv_coord_t w_cont = lv_obj_get_width(old_menu_cont);
+        uint32_t start = !menu_btn_right ? 0 : w_scr-w_cont;
+        uint32_t end = !menu_btn_right ? -w_cont : w_scr;
+        lv_anim_set_values(&a, start, end);
         lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
         lv_anim_set_time(&a, LV_SETTINGS_ANIM_TIME, 0);
         lv_anim_set_ready_cb(&a, old_cont_del_cb);
@@ -751,7 +770,10 @@ static void header_back_event_cb(lv_obj_t * btn, lv_event_t e)
 
     if(act_cont) {
         lv_anim_del(act_cont, (lv_anim_exec_xcb_t)lv_obj_set_x);
-        lv_obj_set_x(act_cont, 0);
+        lv_coord_t w_scr = lv_obj_get_width(lv_scr_act());
+        bool menu_btn_right = lv_obj_get_x(menu_btn) >= w_scr/2;
+        lv_coord_t w_cont = lv_obj_get_width(act_cont);
+        lv_obj_set_x(act_cont, !menu_btn_right ? 0 : w_scr-w_cont);
     }
 }
 

--- a/src/lv_settings/lv_settings.c
+++ b/src/lv_settings/lv_settings.c
@@ -160,7 +160,7 @@ void lv_settings_set_group(lv_group_t * g)
 
 /**
  * Change the maximum width of settings dialog object
- * @param settings pointer to settings object
+ * @param settings pointer to settings object. Not used right now, can be NULL.
  * @param max_width maximum width of the settings container page
  */
 void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width)

--- a/src/lv_settings/lv_settings.c
+++ b/src/lv_settings/lv_settings.c
@@ -14,6 +14,8 @@
 #define LV_SETTINGS_ANIM_TIME   300 /*[ms]*/
 #define LV_SETTINGS_MAX_WIDTH   250
 
+static lv_coord_t settings_max_width = LV_SETTINGS_MAX_WIDTH;
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -158,6 +160,17 @@ void lv_settings_set_group(lv_group_t * g)
 }
 
 /**
+ * Change the maximum width of settings dialog object
+ * @param settings pointer to settings object
+ * @param max_width maximum width of the settings container page
+ */
+void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width)
+{
+    (void)settings;
+    settings_max_width = max_width;
+}
+
+/**
  * Create a new page ask `event_cb` to add the item with `LV_EVENT_REFRESH`
  * @param parent_item pointer to an item which open the the new page. Its `name` will be the title
  * @param event_cb event handler of the menu page
@@ -226,7 +239,7 @@ void lv_settings_refr(lv_settings_item_t * item)
  */
 static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb)
 {
-    lv_coord_t w = LV_MATH_MIN(lv_obj_get_width(lv_scr_act()), LV_SETTINGS_MAX_WIDTH);
+    lv_coord_t w = LV_MATH_MIN(lv_obj_get_width(lv_scr_act()), settings_max_width);
 
     lv_obj_t * old_menu_cont = act_cont;
 
@@ -254,9 +267,9 @@ static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb
     lv_obj_t * header_title = lv_label_create(header, NULL);
     lv_label_set_text(header_title, parent_item->name);
 
-    bool menu_btn_right = lv_obj_get_x(menu_btn) > lv_obj_get_width(lv_scr_act())/2;
+    bool menu_btn_right = lv_obj_get_x(menu_btn) >= lv_obj_get_width(lv_scr_act())/2;
 
-    if(!menu_btn_right ) {
+    if(!menu_btn_right) {
         lv_cont_set_layout(header, LV_LAYOUT_ROW_M);
         lv_label_set_text(header_back_label, LV_SYMBOL_LEFT);
     } else {

--- a/src/lv_settings/lv_settings.c
+++ b/src/lv_settings/lv_settings.c
@@ -160,12 +160,10 @@ void lv_settings_set_group(lv_group_t * g)
 
 /**
  * Change the maximum width of settings dialog object
- * @param settings pointer to settings object. Not used right now, can be NULL.
  * @param max_width maximum width of the settings container page
  */
-void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width)
+void lv_settings_set_max_width(lv_coord_t max_width)
 {
-    (void)settings;
     settings_max_width = max_width;
 }
 

--- a/src/lv_settings/lv_settings.h
+++ b/src/lv_settings/lv_settings.h
@@ -74,10 +74,9 @@ void lv_settings_set_group(lv_group_t * g);
 
 /**
  * Change the maximum width of settings dialog object
- * @param settings pointer to settings object
  * @param max_width maximum width of the settings container page
  */
-void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width);
+void lv_settings_set_max_width(lv_coord_t max_width);
 
 /**
  * Create a new page ask `event_cb` to add the item with `LV_EVENT_REFRESH`

--- a/src/lv_settings/lv_settings.h
+++ b/src/lv_settings/lv_settings.h
@@ -43,7 +43,7 @@ typedef struct {
     lv_settings_type_t type;
     char * name;          /*Name or title of the item*/
     char * value;         /*The current value as string*/
-    int32_t state;              /*The current state, e.g. slider's value, switch state as a number */
+    int32_t state;        /*The current state, e.g. slider's value, switch state as a number */
     lv_obj_t * cont;
     union {
         void * ptr;
@@ -71,6 +71,13 @@ lv_obj_t * lv_settings_create(lv_settings_item_t * root_item, lv_event_cb_t even
  * @param g the group to use. `NULL` to not use this feature.
  */
 void lv_settings_set_group(lv_group_t * g);
+
+/**
+ * Change the maximum width of settings dialog object
+ * @param settings pointer to settings object
+ * @param max_width maximum width of the settings container page
+ */
+void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width);
 
 /**
  * Create a new page ask `event_cb` to add the item with `LV_EVENT_REFRESH`


### PR DESCRIPTION
Hi,
I have changed the settings module to allow for menu placement on the right hand side os the screen.
The default behaviour will not change, but If the settings button is placed on the right hand side of the screen then menu is also placed there. In this case the animations occur from outside right inward on page creation, and vice versa on deletion.

Also, is there a case for being able to set the settings container width ?, 
instead of 
```c
#define LV_SETTINGS_MAX_WIDTH 250

static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb)
{
    lv_coord_t w = LV_MATH_MIN(lv_obj_get_width(lv_scr_act()), LV_SETTINGS_MAX_WIDTH);
    ....
}
```
You have,
```c
#define LV_SETTINGS_MAX_WIDTH 250
lv_coord_t settings_max_width = LV_SETTINGS_MAX_WIDTH;

/**
 * Change the maximum width of settings dialog object
 * @param settings pointer to settings object
 * @param max_width maximum width of the settings container page
 */
void lv_settings_set_max_width(lv_obj_t * settings, lv_coord_t max_width)
{
    settings_max_width = max_width;
}

static void create_page(lv_settings_item_t * parent_item, lv_event_cb_t event_cb)
{
    lv_coord_t w = LV_MATH_MIN(lv_obj_get_width(lv_scr_act()), settings_max_width);
    ....
}
```
![settings](https://user-images.githubusercontent.com/1963675/64584017-9a117780-d393-11e9-9dc6-4bb6ae4bcf2b.PNG)
